### PR TITLE
Implement transport providers for configuring client transports

### DIFF
--- a/client/client_abstract.ts
+++ b/client/client_abstract.ts
@@ -1,8 +1,7 @@
 import { Connection } from "../connection/connection.ts";
-import { ConnectionWebSocket } from "../connection/connection_web_socket.ts";
-import { initTgCrypto } from "../deps.ts";
 import { Transport } from "../transport/transport.ts";
-import { TransportIntermediate } from "../transport/transport_intermediate.ts";
+import { defaultTransportProvider } from "../transport/transport_provider.ts";
+import { initTgCrypto } from "../deps.ts";
 
 export abstract class ClientAbstract {
   connection: Connection;
@@ -10,17 +9,11 @@ export abstract class ClientAbstract {
   dcId: number;
   protected connected = false;
 
-  constructor(protected test = false) {
-    this.dcId = 2;
-    const protocol = typeof location === "undefined" ? "wss" : location.protocol == "http:" ? "ws" : "wss";
-    if (test) {
-      this.connection = new ConnectionWebSocket(`${protocol}://venus.web.telegram.org/apiws_test`);
-      this.dcId += 10000;
-    } else {
-      this.connection = new ConnectionWebSocket(`${protocol}://venus.web.telegram.org/apiws`);
-    }
-    // this.connection = new ConnectionTCP("127.0.0.1", 4430);
-    this.transport = new TransportIntermediate(this.connection, true);
+  constructor(transportProvider = defaultTransportProvider()) {
+    const { connection, transport, dcId } = transportProvider(false);
+    this.connection = connection;
+    this.transport = transport;
+    this.dcId = dcId;
   }
 
   async connect() {

--- a/transport/transport_provider.ts
+++ b/transport/transport_provider.ts
@@ -1,0 +1,32 @@
+import { Connection } from "../connection/connection.ts";
+import { ConnectionWebSocket } from "../connection/connection_web_socket.ts";
+import { Transport } from "./transport.ts";
+import { TransportIntermediate } from "./transport_intermediate.ts";
+
+export interface TransportProviderParams {
+  dc: "1" | "2" | "3" | "4" | "5" | "1-test" | "2-test" | "3-test";
+}
+
+export type TransportProvider = (params?: TransportProviderParams) => (cdn: boolean) => { connection: Connection; transport: Transport; dcId: number };
+
+export const defaultDc: TransportProviderParams["dc"] = "2-test";
+const dcToNameMap: Record<TransportProviderParams["dc"], string> = {
+  "1": "pluto",
+  "1-test": "pluto",
+  "2": "venus",
+  "2-test": "venus",
+  "3": "aurora",
+  "3-test": "aurora",
+  "4": "vesta",
+  "5": "flora",
+};
+export const defaultTransportProvider: TransportProvider = (params?: TransportProviderParams & { wss?: boolean }) => {
+  return (cdn) => {
+    const { dc, wss = typeof location !== "undefined" && location.protocol == "http:" ? false : true } = params ?? { dc: defaultDc };
+    const url = `${wss ? "wss" : "ws"}://${dcToNameMap[dc]}${cdn ? "-1" : ""}.telegram.org/apiws${dc.endsWith("-test") ? "apiws_test" : "apiws"}`;
+    const connection = new ConnectionWebSocket(url);
+    const transport = new TransportIntermediate(connection, true);
+    const dcId = Number(dc[0]) + (dc.endsWith("-test") ? 10_000 : 0) * (cdn ? -1 : 1);
+    return { connection, transport, dcId };
+  };
+};


### PR DESCRIPTION
Also implements a default transport provider that connects to the test DC2 if the `dc` parameter is not provided.