### PR TITLE
Implement `Client.authorize()` for bots

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -177,7 +177,7 @@ export class Client extends ClientAbstract {
           throw err;
         }
       }
-      
+
       let decrypted: Message | MessageContainer;
       try {
         decrypted = await decryptMessage(

--- a/client/client.ts
+++ b/client/client.ts
@@ -1,6 +1,6 @@
 import { gunzip } from "../deps.ts";
 import { MaybePromise } from "../types.ts";
-import { ackThreshold } from "../constants.ts";
+import { ackThreshold, DEFAULT_APP_VERSION, DEFAULT_DEVICE_MODEL, DEFAULT_LANG_CODE, DEFAULT_LANG_PACK, DEFAULT_SYSTEM_LANG_CODE, DEFAULT_SYSTEM_VERSION, LAYER } from "../constants.ts";
 import { getRandomBigInt } from "../utilities/0_bigint.ts";
 import { decryptMessage, encryptMessage, getMessageId } from "../utilities/1_message.ts";
 import { MaybeVectorTLObject } from "../tl/1_tl_object.ts";
@@ -14,7 +14,14 @@ import { ClientAbstract } from "./client_abstract.ts";
 import { ClientPlain } from "./client_plain.ts";
 import { Session } from "../session/session.ts";
 import { SessionMemory } from "../session/session_memory.ts";
-import { TransportProvider } from "../transport/transport_provider.ts";
+import { DC, TransportProvider } from "../transport/transport_provider.ts";
+
+export interface AuthorizeUserParams<S = string, N = { first: S; last: S }> {
+  phone: S | (() => MaybePromise<S>);
+  code: S | (() => MaybePromise<S>);
+  password: S | (() => MaybePromise<S>);
+  names: N | (() => MaybePromise<N>);
+}
 
 export type UpdatesHandler = null | ((client: Client, update: types.Updates) => MaybePromise<void>);
 
@@ -25,31 +32,124 @@ export class Client extends ClientAbstract {
   private toAcknowledge = new Set<bigint>();
   public updatesHandler: UpdatesHandler = null;
 
-  constructor(public readonly session: Session = new SessionMemory(), params?: { transportProvider?: TransportProvider }) {
+  public readonly appVersion: string;
+  public readonly deviceModel: string;
+  public readonly langCode: string;
+  public readonly langPack: string;
+  public readonly systemLangCode: string;
+  public readonly systemVersion: string;
+
+  constructor(
+    public readonly session: Session = new SessionMemory(),
+    public readonly apiId = 0,
+    public readonly apiHash = "",
+    params?: {
+      transportProvider?: TransportProvider;
+      appVersion: string;
+      deviceModel: string;
+      langCode: string;
+      langPack: string;
+      systemLangCode: string;
+      systemVersion: string;
+    },
+  ) {
     super(params?.transportProvider);
+
+    this.appVersion = params?.appVersion ?? DEFAULT_APP_VERSION;
+    this.deviceModel = params?.deviceModel ?? DEFAULT_DEVICE_MODEL;
+    this.langCode = params?.langCode ?? DEFAULT_LANG_CODE;
+    this.langPack = params?.langPack ?? DEFAULT_LANG_PACK;
+    this.systemLangCode = params?.systemLangCode ?? DEFAULT_SYSTEM_LANG_CODE;
+    this.systemVersion = params?.systemVersion ?? DEFAULT_SYSTEM_VERSION;
+  }
+
+  setDc(dc: DC) {
+    if (this.session.dc != dc) {
+      this.session.dc = dc;
+      this.session.authKey = null;
+    }
+    super.setDc(dc);
   }
 
   async connect() {
     await this.session.load();
     if (this.session.authKey == null) {
       const plain = new ClientPlain(this.transportProvider);
+      if (this.session.dc != null) {
+        plain.setDc(this.session.dc);
+      }
       await plain.connect();
       const { authKey, salt } = await plain.createAuthKey();
       await plain.disconnect();
       this.state.salt = salt;
       this.session.authKey = authKey;
-      await this.session.save();
     }
     if (this.session.dc != null) {
-      const { connection, transport, dcId } = this.transportProvider({ dc: this.session.dc, cdn: false });
-      this.connection = connection;
-      this.transport = transport;
-      this.dcId = dcId;
+      this.setDc(this.session.dc);
     }
+    await this.session.save();
     await super.connect();
     // logger().debug("Client connected");
     this.receiveLoop();
     this.pingLoop();
+  }
+
+  async authorize(params: string | AuthorizeUserParams) {
+    if (!this.apiId) {
+      throw new Error("apiId not set");
+    }
+    if (!this.apiHash) {
+      throw new Error("apiHash not set");
+    }
+
+    await this.invoke(
+      new functions.InitConnection({
+        apiId: this.apiId,
+        appVersion: this.appVersion,
+        deviceModel: this.deviceModel,
+        langCode: this.langCode,
+        langPack: this.langPack,
+        query: new functions.InvokeWithLayer({
+          layer: LAYER,
+          query: new functions.HelpGetConfig(),
+        }),
+        systemLangCode: this.systemLangCode,
+        systemVersion: this.systemVersion,
+      }),
+    );
+
+    try {
+      await this.invoke(new functions.UpdatesGetState());
+      return;
+    } catch (err) {
+      if (!(err instanceof types.RPCError) || err.errorMessage != "AUTH_KEY_UNREGISTERED") {
+        throw err;
+      }
+    }
+
+    try {
+      if (typeof params == "object") {
+        throw new Error("Not implemented");
+      } else {
+        await this.invoke(new functions.AuthImportBotAuthorization({ apiId: this.apiId, apiHash: this.apiHash, botAuthToken: params, flags: 0 }));
+      }
+    } catch (err) {
+      if (err instanceof types.RPCError) {
+        const match = err.errorMessage.match(/MIGRATE_(\d)$/);
+        if (match) {
+          let newDc = match[1];
+          if (this.dcId) {
+            newDc += "-test";
+          }
+          await this.reconnect(newDc as DC);
+          await this.authorize(params);
+        } else {
+          throw err;
+        }
+      } else {
+        throw err;
+      }
+    }
   }
 
   private async receiveLoop() {

--- a/client/client_abstract.ts
+++ b/client/client_abstract.ts
@@ -2,19 +2,30 @@ import { initTgCrypto } from "../deps.ts";
 import { DEFAULT_INITIAL_DC } from "../constants.ts";
 import { Connection } from "../connection/connection.ts";
 import { Transport } from "../transport/transport.ts";
-import { defaultTransportProvider } from "../transport/transport_provider.ts";
+import { DC, defaultTransportProvider } from "../transport/transport_provider.ts";
 
 export abstract class ClientAbstract {
   protected connection: Connection;
   protected transport: Transport;
-  dcId: number;
+  private _dcId: number;
   protected connected = false;
 
   constructor(protected transportProvider = defaultTransportProvider({ initialDc: DEFAULT_INITIAL_DC })) {
     const { connection, transport, dcId } = transportProvider({ cdn: false });
     this.connection = connection;
     this.transport = transport;
-    this.dcId = dcId;
+    this._dcId = dcId;
+  }
+
+  get dcId() {
+    return this._dcId;
+  }
+
+  setDc(dc: DC) {
+    const { connection, transport, dcId } = this.transportProvider({ dc, cdn: false });
+    this.connection = connection;
+    this.transport = transport;
+    this._dcId = dcId;
   }
 
   async connect() {
@@ -22,6 +33,14 @@ export abstract class ClientAbstract {
     await this.connection.open();
     await this.transport.initialize();
     this.connected = true;
+  }
+
+  async reconnect(dc?: DC) {
+    await this.disconnect();
+    if (dc) {
+      this.setDc(dc);
+    }
+    await this.connect();
   }
 
   async disconnect() {

--- a/constants.ts
+++ b/constants.ts
@@ -65,3 +65,18 @@ export const publicKeys = new Map<bigint, [bigint, bigint]>([
 export const VECTOR_CONSTRUCTOR = 0x1CB5C415;
 
 export const DEFAULT_INITIAL_DC: DC = "2-test";
+
+export const LAYER = 158;
+
+// TODO
+export const DEFAULT_APP_VERSION = "MTKruto Unstable <v1.0.0";
+
+export const DEFAULT_DEVICE_MODEL = "Krutaya Device";
+
+export const DEFAULT_LANG_CODE = "en";
+
+export const DEFAULT_LANG_PACK = "";
+
+export const DEFAULT_SYSTEM_LANG_CODE = "en";
+
+export const DEFAULT_SYSTEM_VERSION = "1.0";

--- a/mod.ts
+++ b/mod.ts
@@ -19,4 +19,4 @@ export * from "./transport/transport.ts";
 export * from "./transport/transport_provider.ts";
 export * from "./connection/connection.ts";
 export * from "./connection/connection_web_socket.ts";
-export { DEFAULT_INITIAL_DC } from "./constants.ts";
+export { DEFAULT_APP_VERSION, DEFAULT_DEVICE_MODEL, DEFAULT_INITIAL_DC, DEFAULT_LANG_CODE, DEFAULT_LANG_PACK, DEFAULT_SYSTEM_LANG_CODE, DEFAULT_SYSTEM_VERSION, LAYER } from "./constants.ts";

--- a/session/session.ts
+++ b/session/session.ts
@@ -1,8 +1,8 @@
 import { MaybePromise } from "../types.ts";
-import { TransportProviderParams } from "../transport/transport_provider.ts";
+import { DC } from "../transport/transport_provider.ts";
 
 export abstract class Session {
-  dc: TransportProviderParams["dc"] | null = null;
+  dc: DC | null = null;
   authKey: Uint8Array | null = null;
   abstract load(): MaybePromise<void>;
   abstract save(): MaybePromise<void>;


### PR DESCRIPTION
- Fix type of `Session.dc`.
- Make `dcId` a private property of `ClientAbstract` named `_dcId` that will only be changed from `setDc()` — convert `dcId` to a getter.
- Add the method `ClientAbstract.reconnect()` that reconnects the connection, optionally with a new DC.
- Add optional `apiId` and `apiHash` parameters to `Client`’s constructor.
- Add the method `Client.authorize()` that calls `InitConnection`, and imports bot authorization if not already authorized.