### PR TITLE
Add default connectionState and FloodWait handlers

### DIFF
--- a/client/3_types.ts
+++ b/client/3_types.ts
@@ -38,6 +38,10 @@ export interface ClientParams extends ClientPlainParams {
    * Whether to automatically call `start` with no parameters in the first `invoke` call. Defaults to `true`.
    */
   autoStart?: boolean;
+  /**
+   * Whether to use default handlers. Defaults to `true`.
+   */
+  defaultHandlers?: boolean;
 }
 
 export interface AnswerCallbackQueryParams {

--- a/client/4_client.ts
+++ b/client/4_client.ts
@@ -112,6 +112,38 @@ export class Client extends ClientAbstract {
     this.systemVersion = params?.systemVersion ?? SYSTEM_VERSION;
     this.#publicKeys = params?.publicKeys;
     this.#autoStart = params?.autoStart ?? true;
+
+    if (params?.defaultHandlers ?? true) {
+      this.on("connectionState", async ({ connectionState }) => {
+        if (connectionState == "notConnected") {
+          let delay = 5;
+          while (!this.connected) {
+            d("reconnecting");
+            try {
+              await this.connect();
+              d("reconnected");
+              break;
+            } catch (err) {
+              d("failed to reconnect, retrying in %d: %o", delay, err);
+            }
+            await new Promise((r) => setTimeout(r, delay * 1_000)); 
+            if (delay < 15) {
+              delay += 5
+            }
+          }
+        }
+      });
+
+      this.invoke.use(async ({error}, next) => { 
+        if (error instanceof FloodWait && error.seconds <= 10) {
+          d("sleeping for %d because of: %o", error.seconds, error)
+          await new Promise((r) => setTimeout(r, 1000 * error.seconds));
+          return true;
+        } else {
+          return next();
+        }
+      });
+    }
   }
 
   #constructContext = (update: Update) => {

--- a/client/4_client.ts
+++ b/client/4_client.ts
@@ -126,17 +126,17 @@ export class Client extends ClientAbstract {
             } catch (err) {
               d("failed to reconnect, retrying in %d: %o", delay, err);
             }
-            await new Promise((r) => setTimeout(r, delay * 1_000)); 
+            await new Promise((r) => setTimeout(r, delay * 1_000));
             if (delay < 15) {
-              delay += 5
+              delay += 5;
             }
           }
         }
       });
 
-      this.invoke.use(async ({error}, next) => { 
+      this.invoke.use(async ({ error }, next) => {
         if (error instanceof FloodWait && error.seconds <= 10) {
-          d("sleeping for %d because of: %o", error.seconds, error)
+          d("sleeping for %d because of: %o", error.seconds, error);
           await new Promise((r) => setTimeout(r, 1000 * error.seconds));
           return true;
         } else {


### PR DESCRIPTION
- Try reconnecting directly after the connection is closed, and after 3 different delays afterwards.
- Automatically sleep and retry requests that caused a flood wait of 10 seconds or less.
