### PR TITLE
Support different command prefixes and default to “\” for users

### DIFF
--- a/client/3_types.ts
+++ b/client/3_types.ts
@@ -45,6 +45,10 @@ export interface ClientParams extends ClientPlainParams {
    * Whether to ignore outgoing messages. Defaults to `true` for bots, and `false` for users.
    */
   ignoreOutgoing?: boolean;
+  /**
+   * Default command prefixes. Defaults to `"/"` for bots and `"\"` for users. This option must be set separately for nested composers.
+   */
+  prefixes?: string | string[];
 }
 
 export interface AnswerCallbackQueryParams {

--- a/client/5_client.ts
+++ b/client/5_client.ts
@@ -102,6 +102,7 @@ export class Client<C extends Context = Context> extends ClientAbstract {
   readonly #publicKeys?: PublicKeys;
   readonly #autoStart: boolean;
   readonly #ignoreOutgoing: boolean | null;
+  readonly #prefixes?: string | string[];
 
   /**
    * Constructs the client.
@@ -130,6 +131,7 @@ export class Client<C extends Context = Context> extends ClientAbstract {
     this.#publicKeys = params?.publicKeys;
     this.#autoStart = params?.autoStart ?? true;
     this.#ignoreOutgoing = params?.ignoreOutgoing ?? null;
+    this.#prefixes = params?.prefixes;
 
     if (params?.defaultHandlers ?? true) {
       this.on("connectionState", ({ connectionState }, next) => {
@@ -2160,21 +2162,44 @@ export class Client<C extends Context = Context> extends ClientAbstract {
     }, ...middleawre);
   }
 
-  command(commands: string | RegExp | (string | RegExp)[], ...middleawre: Middleware<FilterUpdate<C, "message", "text">>[]) {
-    const commands_ = Array.isArray(commands) ? commands : [commands];
+  command(
+    commands: string | RegExp | (string | RegExp)[] | {
+      names: string | RegExp | (string | RegExp)[];
+      prefixes: string | string[];
+    },
+    ...middleawre: Middleware<FilterUpdate<C, "message", "text">>[]
+  ) {
+    const commands__ = typeof commands === "object" && "names" in commands ? commands.names : commands;
+    const commands_ = Array.isArray(commands__) ? commands__ : [commands__];
+    const prefixes_ = typeof commands === "object" && "prefixes" in commands ? commands.prefixes : (this.#prefixes ?? []);
+    const prefixes = Array.isArray(prefixes_) ? prefixes_ : [prefixes_];
+    for (const left of prefixes) {
+      for (const right of prefixes) {
+        if (left == right) {
+          continue;
+        }
+        if (left.startsWith(right) || right.startsWith(left)) {
+          throw new Error("Intersecting prefixes");
+        }
+      }
+    }
     return this.on(["message", "text"]).filter((ctx) => {
-      const botCommand = ctx.message.entities?.find((v) => v.type == "botCommand");
-      if (!botCommand) {
+      const prefixes_ = prefixes.length == 0 ? [!ctx.me?.isBot ? "\\" : "/"] : prefixes;
+      if (prefixes_.length == 0) {
         return false;
       }
-      const cmd = ctx.message.text!.slice(botCommand.offset, botCommand.offset + botCommand.length);
+      const cmd = ctx.message.text.split(/\s/, 1)[0];
+      const prefix = prefixes_.find((v) => cmd.startsWith(v));
+      if (prefix === undefined) {
+        return false;
+      }
       if (cmd.includes("@")) {
-        const username = cmd.split("@")[1];
+        const username = cmd.split("@", 2)[1];
         if (username.toLowerCase() !== ctx.me!.username?.toLowerCase()) {
           return false;
         }
       }
-      const command_ = cmd.split("@")[0].split("/")[1].toLowerCase();
+      const command_ = cmd.split("@", 1)[0].split(prefix, 2)[1].toLowerCase();
       for (const command of commands_) {
         if (typeof command === "string" && (command.toLowerCase() == command_)) {
           return true;


### PR DESCRIPTION
## Usage

```ts
client.command({ names: "start", prefixes: ["!", "/"] }, (ctx) => {});
```

## Client Default

```ts
const client = new Client(storage, apiId, apiHash, { prefixes: ["!", "/"] });
```

## Composer Default

```ts
const composer = new Composer();
composer.prefixes = ["!", "/"];
```

## Notes

- The default command prefix for users is now the backslash character, “\”.